### PR TITLE
Update 4_118_get_openrouter_api_credentials.html

### DIFF
--- a/project_29_console_chat_with_llm/4_118_get_openrouter_api_credentials.html
+++ b/project_29_console_chat_with_llm/4_118_get_openrouter_api_credentials.html
@@ -18,7 +18,7 @@ What do I need to write myself in the @project-rules.txt file for the app to be 
 
 <content-template name="model_warning"></content-template>
 
-<p>After you choose the model, copy the model name to the task-description.txt file.</p>
+<p>After you choose the model, copy the model name to the project-rules.txt file.</p>
 <p>
   <img style="width: 100%;" src="https://ucarecdn.com/93830103-c6f2-4821-a2cc-7429636b153e/" alt="Usage of free models">
 </p>


### PR DESCRIPTION
This pull request includes a minor update to the instructions in the `project_29_console_chat_with_llm/4_118_get_openrouter_api_credentials.html` file. The change updates the file name referenced in the instructions from `task-description.txt` to `project-rules.txt`.